### PR TITLE
Fix typo: `datadir` -> `dataDir`

### DIFF
--- a/js/postgres.js
+++ b/js/postgres.js
@@ -125,7 +125,7 @@ function render({ model, el }) {
 
     try {
       const db = await PGlite.create({
-        datadir: idb,
+        dataDir: idb,
         options: options,
         extensions: extensionsObj,
       });


### PR DESCRIPTION
## Summary

This PR fixes a typo where the field name was mistakenly written as `datadir` instead of `dataDir`([PGlite source code](https://github.com/electric-sql/pglite/blob/93a4087029c929a273606c8599d6ea3df7fc5267/packages/pglite/src/interface.ts#L80-L81)). Previously, because the correct field name was not used, data was not persisted to IndexedDB. With this fix, the data is now correctly persisted.

## Changes

Changed:
```js
const db = await PGlite.create({
  datadir: idb,
  options: options,
  extensions: extensionsObj,
});
````
to:
```js
const db = await PGlite.create({
  dataDir: idb,
  options: options,
  extensions: extensionsObj,
});
```